### PR TITLE
feat: add toggle for access key creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# IAM Service User
-
-Creates a IAM user account with a provided policy to control IAM permissions. Since this is a service role that is meant for programmatic access via applcations/automations, an MFA will not be required for authenticating as this user.
-
 ## Requirements
 
 No requirements.
@@ -12,16 +8,32 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_access_key.iam_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_user.iam_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
+| [aws_iam_user_policy_attachment.iam_attach_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| create\_access\_key | Create user access key if enabled | `bool` | `true` | no |
+| enable\_gcci\_boundary | toggle for gcci boundary to allow non-gcc accounts to create role | `bool` | `true` | no |
 | pgp\_key | pgp key to use to encrypt the access keys - use 'gpg --export %KEY\_ID% \| base64 -w 0' to get this value | `string` | n/a | yes |
 | purpose | a reason why this user should exist | `string` | n/a | yes |
-| user\_attach\_policy | map(string) of existing policies to attach directly | `map(string)` | `{}` | no |
-| user\_policy | policy attached to user directly | `string` | `""` | no |
+| user\_attach\_policy | map(string) of existing policies to attach directly to user | `map(string)` | `{}` | no |
+| user\_policy | IAM policy attached directly to user | `string` | `""` | no |
 | username | username for the user | `string` | `"gcc-default-user"` | no |
-| enable\_gcci\_boundary | permission boundary toggle | `bool` | `true` | no |
+| username\_prefix | prefix for username | `string` | `"service"` | no |
 
 ## Outputs
 
@@ -32,4 +44,3 @@ No requirements.
 | arn | arn of the created iam user |
 | id | id of the created iam user |
 | name | username of the created iam user |
-

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_iam_user" "iam_user" {
 
 # ref https://www.terraform.io/docs/providers/aws/r/iam_access_key.html
 resource "aws_iam_access_key" "iam_user" {
-  count   = var.create_access_key == true ? 1 : 0
+  count   = var.create_access_key ? 1 : 0
   user    = aws_iam_user.iam_user.name
   pgp_key = var.pgp_key
 }

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ resource "aws_iam_user" "iam_user" {
 
 # ref https://www.terraform.io/docs/providers/aws/r/iam_access_key.html
 resource "aws_iam_access_key" "iam_user" {
+  count   = var.create_access_key == true ? 1 : 0
   user    = aws_iam_user.iam_user.name
   pgp_key = var.pgp_key
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,10 +15,10 @@ output "name" {
 
 output "access_key_id" {
   description = "id of the access key"
-  value       = "${aws_iam_access_key.iam_user.id}"
+  value       = "${aws_iam_access_key.iam_user.*.id}"
 }
 
 output "access_key" {
   description = "base64-encoded, encrypted access key of the user, use `base64 -d` to decrypt and `gpg -d encrypted.txt`"
-  value       = "${aws_iam_access_key.iam_user.encrypted_secret}"
+  value       = "${aws_iam_access_key.iam_user.*.encrypted_secret}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,9 @@ variable "enable_gcci_boundary" {
   type        = bool
   default     = true
 }
+
+variable "create_access_key" {
+  description = "Create user access key if enabled"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
- Feature toggle for access key creation

In the event that user has already rotated his access key but we still need to update his permissions without removing his current key and creating a new one.